### PR TITLE
fix build issues by adding include to time.h

### DIFF
--- a/ttyload.h
+++ b/ttyload.h
@@ -8,6 +8,8 @@
  *
  */
 
+#include <time.h>
+
 #define	MIN(a,b)	(((a)<(b))?(a):(b))
 #define	MAX(a,b)	(((a)>(b))?(a):(b))
 


### PR DESCRIPTION
Current version 0.5.3 does not compile due to a missing include for time.h, gcc complains of not knowing about time_t(). 
