### PR TITLE
Update ttyload.c

### DIFF
--- a/ttyload.c
+++ b/ttyload.c
@@ -15,7 +15,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <sys/fcntl.h>
+#include <fcntl.h>
 #include <sys/stat.h>
 #include <time.h>
 #include <sys/types.h>


### PR DESCRIPTION
fix for a warning on alpine linux:
```/usr/include/sys/fcntl.h:1:2: error: #warning redirecting incorrect #include <sys/fcntl.h> to <fcntl.h> [-Werror=cpp]
 #warning redirecting incorrect #include <sys/fcntl.h> to <fcntl.h>```